### PR TITLE
⚡ Bolt: Remove unused font (Inter)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-13 - Unused Next.js Font Import
+**Learning:** Next.js font instantiations (like `Inter()`) trigger build-time processing (downloading, generating CSS) even if the generated CSS class is never applied in the DOM.
+**Action:** Always check if instantiated fonts are actually used in the render tree; removing unused ones saves build time and potential bundle bloat.

--- a/core-app/src/app/layout.tsx
+++ b/core-app/src/app/layout.tsx
@@ -2,14 +2,16 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { GeistSans } from "geist/font/sans";
 import { ThemeProvider } from "@/providers/ThemeProvider";
-import { Inter } from "next/font/google";
 
 export const metadata: Metadata = {
   title: "Cyber Fortress - IT Solutions",
   description: "",
   icons: "",
 };
-const inter = Inter({ subsets: ["latin"] });
+
+// ⚡ Bolt: Removed unused font (Inter) import and instantiation.
+// Previously, Next.js would fetch and process the unused Inter font at build time.
+// Removing this dead code prevents unnecessary build-time work and reduces potential bundle size bloat.
 export default function RootLayout({
   children,
 }: Readonly<{


### PR DESCRIPTION
💡 **What:** Removed unused `Inter` font import and initialization from `src/app/layout.tsx`. Added comment explaining the optimization.
🎯 **Why:** In Next.js, calling font functions like `Inter()` triggers the font to be fetched and processed at build time, generating CSS even if the variable isn't injected into the DOM. Removing this dead code prevents unnecessary build-time work and potential bundle bloat.
📊 **Impact:** Slightly faster build times and zero risk of unused CSS/font bloating the final application bundle.
🔬 **Measurement:** Verify the font is no longer included in the generated `.css` assets by inspecting the `.next/static/css/` directory after running `npm run build`.

---
*PR created automatically by Jules for task [6435153376451745588](https://jules.google.com/task/6435153376451745588) started by @lakshyarawat1*