### PR TITLE
🧹 [Code Health] Remove unused Props type from Navbar

### DIFF
--- a/core-app/src/components/global/Navbar.tsx
+++ b/core-app/src/components/global/Navbar.tsx
@@ -12,11 +12,9 @@ import { ModeToggle } from "./ModeToggle";
 import { Button } from "../ui/button";
 import { cn } from "@/lib/utils";
 
-type Props = {};
-
 const icon = "icon.ico";
 
-const Navbar = (props: Props) => {
+const Navbar = () => {
   return (
     <nav className="md:flex gap-[25%] mx-[35%] my-2 pb-3 md:mx-2 border-b">
       <div className="flex gap-3 items-center">


### PR DESCRIPTION
🎯 **What:** Removed the empty `Props` type definition from `core-app/src/components/global/Navbar.tsx` and updated the `Navbar` signature to take no arguments.
💡 **Why:** The `Props` type was defined as an empty object `{}` and passed to `Navbar`, but it was never used. Removing it improves the maintainability and readability of the codebase by eliminating unnecessary boilerplate.
✅ **Verification:** Ran `npm run lint` and `npm run build` within `core-app/` to ensure no functionality is broken and no lint errors were introduced.
✨ **Result:** A slightly cleaner and more readable component definition for `Navbar`.

---
*PR created automatically by Jules for task [10793415268336864201](https://jules.google.com/task/10793415268336864201) started by @lakshyarawat1*