### PR TITLE
⚡ Bolt: Remove premature priority from below-the-fold images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,7 @@
 ## $(date +%Y-%m-%d) - [Hydration Mismatch with next-themes]
 **Learning:** Found a performance penalty in `layout.tsx` when using `next-themes` without `suppressHydrationWarning` on the `<html>` tag. `next-themes` mutates the `class` or `style` attributes on the client to avoid FOUC. This mismatch with the server-rendered HTML causes React to trigger a full client-side re-render of the root tree, delaying Time to Interactive (TTI) and increasing Total Blocking Time (TBT).
 **Action:** Always add `suppressHydrationWarning` to the root `<html>` tag when integrating `next-themes` in a Next.js App Router project to safely bypass the hydration mismatch check and avoid unnecessary root re-renders.
+
+## 2024-08-01 - [Avoid Premature Image Prioritization in Next.js]
+**Learning:** Found a performance anti-pattern where images mapped in a grid below a large hero section were given `priority={idx < 3}`. Preloading images that are situated below the initial fold wastes critical network bandwidth during the initial page load, competing with essential assets (CSS/fonts/JS) and negatively impacting Largest Contentful Paint (LCP).
+**Action:** Only use the `priority` prop on `next/image` for images definitively verified to appear above the fold (e.g., LCP hero images). For below-the-fold content, rely on Next.js's default `loading="lazy"` behavior to defer loading until they enter the viewport.

--- a/core-app/src/app/page.tsx
+++ b/core-app/src/app/page.tsx
@@ -42,16 +42,18 @@ export default function Home() {
               className="md:max-w-[30%] max-w-[80%] max-h-[50rem] md:max-h-[30rem] mx-auto cursor-pointer hover:shadow-lg duration-500 dark:hover:shadow-slate-700 dark:hover:shadow-lg hover:scale-[102%]"
               key={idx}
             >
-              {/* ⚡ Bolt: Use static imports and sizes attribute for next/image.
-                  Static imports automatically provide width/height and a base64 blur placeholder, dramatically improving perceived LCP and preventing CLS.
-                  The sizes attribute ensures smaller viewports download appropriately scaled images, saving bandwidth. */}
+              {/* ⚡ Bolt: Removed priority prop from below-the-fold images.
+                  These images render below the hero section. Using priority here forces immediate preloading,
+                  wasting critical bandwidth that competes with above-the-fold assets, delaying actual LCP.
+                  Removing priority restores Next.js's default loading="lazy" behavior.
+                  Additionally: Using static imports (automatically provides blur placeholder/dimensions)
+                  and the sizes attribute ensures responsive, bandwidth-efficient rendering without CLS. */}
               <Image
                 src={tile.svg}
                 alt={tile.title}
                 className="rounded-t-lg object-cover w-full md:h-[46%]"
                 placeholder="blur"
                 sizes="(max-width: 768px) 80vw, 30vw"
-                priority={idx < 3}
               />
 
               <CardHeader>


### PR DESCRIPTION
💡 What: Removed the `priority` prop from the `<Image>` component used to map `homeConstants` in `core-app/src/app/page.tsx`.
🎯 Why: These images render in a grid below a large hero section, pushing them below the initial viewport. Giving them `priority` forces the browser to preload them immediately, wasting critical network bandwidth that should be reserved for above-the-fold assets (CSS, fonts, JS).
📊 Impact: Reduces initial network bandwidth contention, improving Largest Contentful Paint (LCP) and time to interactive by restoring Next.js's default `loading="lazy"` behavior for off-screen images.
🔬 Measurement: Verified via code review and by running `pnpm run lint` and `pnpm test`. Run lighthouse (or Next.js bundle analyzer) to see improved LCP metrics for initial page load.

---
*PR created automatically by Jules for task [13846312793206351910](https://jules.google.com/task/13846312793206351910) started by @lakshyarawat1*